### PR TITLE
GGUF export

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -203,6 +203,20 @@ ssh = ["paramiko"]
 tqdm = ["tqdm"]
 
 [[package]]
+name = "gguf"
+version = "0.6.0"
+description = "Read and write ML models in GGUF for GGML"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "gguf-0.6.0-py3-none-any.whl", hash = "sha256:7ef6d0cf27b3cc4f11397140be7cf45b5904b751331ea9453839a17004f06762"},
+    {file = "gguf-0.6.0.tar.gz", hash = "sha256:b2e22eaba2a106c1ad148186a14ad9f29c429351686fe9d7ce16df39a0607e65"},
+]
+
+[package.dependencies]
+numpy = ">=1.17"
+
+[[package]]
 name = "huggingface-hub"
 version = "0.20.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
@@ -1343,4 +1357,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "814772744e78a9363de886d55c595c923c507333364a8436fead9ab9b608405f"
+content-hash = "3bde68443fcdfe53f0bb76051dd53b64cc6abd155ff56e8fa05b96ed318fe4a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ torch = "^2.1.2"
 transformers = "^4.36.2"
 accelerate = "^0.26.1"
 tqdm = "^4.66.1"
+gguf = {version = "^0.6.0", optional = true}
 
 
 [build-system]


### PR DESCRIPTION
Adds a method to export a vector to a `.gguf` file, using an optional `gguf` dependency. This file can't be used with llama.cpp yet.

Also normalizes layer indices passed to `ControlVector`/`ControlModel`—if you pass negative indices, they'll be stored as positive ones now.