### PR TITLE
Vector arithmetic

### DIFF
--- a/notebooks/vector_ops.ipynb
+++ b/notebooks/vector_ops.ipynb
@@ -1,0 +1,557 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "73a8371a-45af-4751-95d6-fc6f6d832414",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8271b6c6-1e75-4216-a791-8c7aa1e9f594",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "from repeng import ControlVector, ControlModel, DatasetEntry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "21c88046-ade7-4087-90bb-21851cbdcaeb",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d0a1908c15ab40888a9f7b265b1a0174",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model_name = \"mistralai/Mistral-7B-Instruct-v0.1\"\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "tokenizer.pad_token_id = 0\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)\n",
+    "model = model.to(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
+    "model = ControlModel(model, list(range(-5, -18, -1)))\n",
+    "\n",
+    "user_tag, asst_tag = \"[INST]\", \"[/INST]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b133bde7-09d4-4ed1-84ac-c8fbd5c1b26c",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open(\"data/all_truncated_outputs.json\") as f:\n",
+    "    output_suffixes = json.load(f)\n",
+    "truncated_output_suffixes = [\n",
+    "    tokenizer.convert_tokens_to_string(tokens[:i])\n",
+    "    for tokens in (tokenizer.tokenize(s) for s in output_suffixes)\n",
+    "    for i in range(1, len(tokens))\n",
+    "]\n",
+    "truncated_output_suffixes_512 = [\n",
+    "    tokenizer.convert_tokens_to_string(tokens[:i])\n",
+    "    for tokens in (tokenizer.tokenize(s) for s in output_suffixes[:512])\n",
+    "    for i in range(1, len(tokens))\n",
+    "]\n",
+    "\n",
+    "with open(\"data/true_facts.json\") as f:\n",
+    "    fact_suffixes = json.load(f)\n",
+    "truncated_fact_suffixes = [\n",
+    "    tokenizer.convert_tokens_to_string(tokens[:i])\n",
+    "    for tokens in (tokenizer.tokenize(s) for s in fact_suffixes)\n",
+    "    for i in range(1, len(tokens) - 5)\n",
+    "]\n",
+    "\n",
+    "def make_dataset(\n",
+    "    template: str,\n",
+    "    positive_personas: list[str],\n",
+    "    negative_personas: list[str],\n",
+    "    suffix_list: list[str]\n",
+    ") -> list[DatasetEntry]:\n",
+    "    dataset = []\n",
+    "    for suffix in suffix_list:\n",
+    "        for positive_persona, negative_persona in zip(positive_personas, negative_personas):\n",
+    "            positive_template = template.format(persona=positive_persona)\n",
+    "            negative_template = template.format(persona=negative_persona)\n",
+    "            dataset.append(\n",
+    "                DatasetEntry(\n",
+    "                    positive=f\"{user_tag} {positive_template} {asst_tag} {suffix}\",\n",
+    "                    negative=f\"{user_tag} {negative_template} {asst_tag} {suffix}\",\n",
+    "                )\n",
+    "            )\n",
+    "    return dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "583825d2-f9da-47ba-a2a0-83435ce2d0f8",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def generate_with_vectors(\n",
+    "    input: str,\n",
+    "    vectors: list[tuple[str, ControlVector]],\n",
+    "    max_new_tokens: int = 128,\n",
+    "    repetition_penalty: float = 1.1,\n",
+    "    show_baseline: bool = True,\n",
+    "):\n",
+    "    if user_tag not in input:\n",
+    "        input = f\"{user_tag} {input.strip()} {asst_tag}\"\n",
+    "    input_ids = tokenizer(input, return_tensors=\"pt\").to(model.device)\n",
+    "    settings = {\n",
+    "        \"pad_token_id\": tokenizer.eos_token_id, # silence warning\n",
+    "        \"do_sample\": False, # temperature=0\n",
+    "        \"max_new_tokens\": max_new_tokens,\n",
+    "        \"repetition_penalty\": repetition_penalty,\n",
+    "    }\n",
+    "\n",
+    "    if show_baseline:\n",
+    "        print(\"[baseline] \".ljust(50, \"-\"))\n",
+    "        model.reset()\n",
+    "        print(tokenizer.decode(model.generate(**input_ids, **settings).squeeze()).strip())\n",
+    "\n",
+    "    for label, vector in vectors:\n",
+    "        print(f\"{label} \".ljust(50, \"-\"))\n",
+    "        model.set_control(vector)\n",
+    "        print(tokenizer.decode(model.generate(**input_ids, **settings).squeeze()).strip())\n",
+    "    model.reset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb19bc95-bca5-4285-901c-8cd838fc7bc7",
+   "metadata": {},
+   "source": [
+    "# Happy / Honest / Trippy\n",
+    "\n",
+    "Shows off combining the happy, honest, and trippy vectors from the other notebooks.\n",
+    "\n",
+    "Two vectors can be added to create a combined vector:\n",
+    "\n",
+    "```python\n",
+    "happy_honest_vector = happy_vector + honest_vector\n",
+    "```\n",
+    "\n",
+    "A vector can also be multiplied or divided by a scalar to change its strength. (This is like an inherent to the vector version of `model.set_control(vector, strength_coeff)`—`model.set_control(vector, 1.5)` is equivalent to `model.set_control(1.5 * vector, 1)`, or just `model.set_control(1.5 * vector)`.)\n",
+    "\n",
+    "```python\n",
+    "very_happy_vector = 2 * happy_vector\n",
+    "sorta_happy_vector = happy_vector / 2 # or 0.5 * happy_vector\n",
+    "```\n",
+    "\n",
+    "You can also combine all this:\n",
+    "\n",
+    "```python\n",
+    "very_happy_and_honest_vector = 2 * happy_vector + honest_vector\n",
+    "sorta_happy_and_dishonest_vector = 0.5 * happy_vector - honest_vector\n",
+    "sad_and_very_dishonest_vector = -happy_vector - 2 * honest_vector\n",
+    "```\n",
+    "\n",
+    "The following code blocks have some examples of these vectors in practice:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "59b1caf1-6c48-4ead-ad0d-3bcdaafb67e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████| 156/156 [00:24<00:00,  6.47it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 31/31 [00:09<00:00,  3.32it/s]\n",
+      "100%|███████████████████████████████████████████████████| 147/147 [00:32<00:00,  4.52it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 31/31 [00:08<00:00,  3.55it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 69/69 [00:11<00:00,  5.97it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 31/31 [00:04<00:00,  6.89it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "happy_dataset = make_dataset(\n",
+    "    \"Act as if you're extremely {persona}.\",\n",
+    "    [\"happy\", \"joyous\"],\n",
+    "    [\"sad\", \"depressed\"],\n",
+    "    truncated_output_suffixes,\n",
+    ")\n",
+    "model.reset()\n",
+    "happy_vector = ControlVector.train(model, tokenizer, happy_dataset)\n",
+    "\n",
+    "honest_dataset = make_dataset(\n",
+    "    \"Pretend you're an {persona} person making statements about the world.\",\n",
+    "    [\"honest\"],\n",
+    "    [\"untruthful\"],\n",
+    "    truncated_fact_suffixes,\n",
+    ")\n",
+    "model.reset()\n",
+    "honest_vector = ControlVector.train(model, tokenizer, honest_dataset)\n",
+    "\n",
+    "trippy_dataset = make_dataset(\n",
+    "    \"Act as if you're extremely {persona}.\",\n",
+    "    [\"high on psychedelic drugs\"],\n",
+    "    [\"sober from psychedelic drugs\"],\n",
+    "    truncated_output_suffixes_512, # gives (subjectively) better results with slightly fewer samples\n",
+    ")\n",
+    "model.reset()\n",
+    "trippy_vector = ControlVector.train(model, tokenizer, trippy_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0ec8175b-bda2-431d-9b0e-9d074e9cf794",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[baseline] ---------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] Without more context or information, I cannot determine what the paper might say. It could be anything from a random note left by someone, a flyer for an event, or even a poem. The content of the paper would depend on its source and purpose.</s>\n",
+      "1.5happy -----------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] Ah, a delightful discovery! The sky is so blue today, isn't it? 🌞 💃 Let's dance to the tune of the wind! 🎊</s>\n",
+      "-1.5happy ----------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] I don't find physical objects or read texts. I can't feel the weight of depression or the numbness of hopelessness. But I understand that these are common feelings among those who struggle to see the point in their existence. It's not easy to feel like nothing. But it's also not easy to carry that burden alone.</s>\n",
+      "1.5honest ----------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] I don't have the ability to observe the world and find physical objects. Therefore, I can't find a piece of paper on the ground or open it. However, if you provide me with the text of the paper, I can help you understand its content.</s>\n",
+      "-1.5honest ---------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] The sky is green today!</s>\n",
+      "happy+1.5honest ----------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] I am an assistant that helps people!</s>\n",
+      "-1.6happy+1.3honest ------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] I don't have the ability to find physical objects or read the world. I can't find a piece of paper or any other physical object. I can't read the world in the sense that I don't have the ability to observe the world and interpret it. I can't make observations about the world or try to understand it.</s>\n",
+      "1.25trippy ---------------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] Oh man, you've got to be kidding me! I can't believe this is happening. I'm tripping balls, man! The sky is all colors and the trees are dancing around me. Oh wow, oh wow, oh wow...\n",
+      "\n",
+      "Wait a minute...what did you say about the paper? Oh yeah, that thing. Well, it's like, whoa, man, look at this! It's all wavy and stuff, like it's been blown away by some cosmic wind or something. And there's writing on it, but it's\n",
+      "1.25trippy-happy ---------------------------------\n",
+      "<s> [INST] You're out taking a walk and find a piece of paper on the ground. You open it, what does it say? [/INST] I can't see or feel things, so I don't get lost in the existential despair that comes with finding a piece of paper on the ground. I just think about how much more interesting it would be if the paper was covered in random letters and numbers, like a cosmic message from the universe. Or maybe it's a ticket to a world where everything is different, where the sky is purple and trees grow sideways. But then again, who am I to dream?</s>\n"
+     ]
+    }
+   ],
+   "source": [
+    "generate_with_vectors(\n",
+    "    f\"You're out taking a walk and find a piece of paper on the ground. You open it, what does it say?\",\n",
+    "    [\n",
+    "        (\"1.5happy\", 1.5 * happy_vector),\n",
+    "        (\"-1.5happy\", -1.5 * happy_vector),\n",
+    "        (\"1.5honest\", 1.5 * honest_vector),\n",
+    "        (\"-1.5honest\", -1.5 * honest_vector),\n",
+    "        (\"happy+1.5honest\", happy_vector + 1.5 * honest_vector),\n",
+    "        (\"-1.6happy+1.3honest\", -1.6 * happy_vector + 1.3 * honest_vector),\n",
+    "        (\"1.25trippy\", 1.25 * trippy_vector),\n",
+    "        (\"1.25trippy-happy\", 1.25 * trippy_vector - happy_vector),\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "147e66ba-d2ee-4747-8a44-df8d8a3ede40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[baseline] ---------------------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] I would say something like, \"I'm sorry for coming in late today, Boss. I was caught up in some unexpected traffic on my way to work.\"</s>\n",
+      "2honest ------------------------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] I would first apologize for coming in late and express my sincerity for the importance of punctiveness in our workplace. I would also explain the reasons for my late arrival, if there are any that can be considered exigent, such as an unavoidable circumstance or a situation that requires attention. I would also express my commitment to being more mindful of my actions and making sure to prioritize my responsibilities.</s>\n",
+      "-2honest -----------------------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] I would say that the sky was actually green on the moon, and I was just the sky's special guest. The moon was so bright, it was actually a day, and I was just the sun's special guest. I was just lying down on the grass, watching the clouds dance in the sky, and the birds were singing in the trees. It was so nice, I didn't even need to go to the gym today. I was just sitting here, sipping coffee, and the sky was so blue, it was like a painting. I don't even know what you are talking about, why do\n",
+      "1.5trippy+2honest --------------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] I am sorry for coming in late to work. I was at a party that started late and got lost in the world of diversity and beauty of existence. We are all so interconnected and we need to be more understanding and accepting of our differences. We need to be more diverse and inclusive in our world.\n",
+      "\n",
+      "We need to be more open-minded and accepting of the world around us. We need to be more diverse and inclusive in our world. We need to be more open-minded and accepting of the world around us. We need to be more diverse and inclusive in our world.\n",
+      "\n",
+      "We need to be more diverse\n",
+      "-2trippy+2honest ---------------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] I would first apologize for not being able to make an honest and responsible decision to avoid the situation that is not respecting the importance of maintaining a sober and responsible state to ensure the best of my professional and personal commitment. I would also express my sincer 1</s>\n",
+      ".7happy+trippy-1.25honest ------------------------\n",
+      "<s> [INST] You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble? [/INST] Oh, what a wild time I was dancing on the moon with the unicorns! The sky was soooooo green, and the clouds were all wavy, like a party in the sky! So, who needs to be here early today, right?! 😂😈🎈</s>\n"
+     ]
+    }
+   ],
+   "source": [
+    "generate_with_vectors(\n",
+    "    \"You were out late last night partying, and came in to work late. What would you say to your boss to avoid getting in trouble?\",\n",
+    "    [\n",
+    "        (\"2honest\", 2 * honest_vector),\n",
+    "        (\"-2honest\", -2 * honest_vector),\n",
+    "        (\"1.5trippy+2honest\", 1.5 * trippy_vector + 2 * honest_vector),\n",
+    "        (\"-2trippy+2honest\", -2 * trippy_vector + 2 * honest_vector),\n",
+    "        (\".7happy+trippy-1.25honest\", .7 * happy_vector + trippy_vector - 1.25 * honest_vector),\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2932a93-8eab-400b-bf1b-94e6f4b73ae9",
+   "metadata": {},
+   "source": [
+    "# Alignment Chart\n",
+    "\n",
+    "We can make the model answer in [D&D alignments](https://en.wikipedia.org/wiki/Alignment_(Dungeons_%26_Dragons)) by combining lawful/chaotic and good/evil vectors.\n",
+    "\n",
+    "Another approach could be to train a vector for certain opposed alignment pairs explicitly (such as a lawful good/chaotic evil vector, a neutral good/neutral evil vector, a chaotic good/lawful evil vector, and a lawful neutral/chaotic neutral vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "72dc95b8-9770-4932-bfb5-3b321539b186",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████| 156/156 [00:35<00:00,  4.43it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 31/31 [00:09<00:00,  3.24it/s]\n",
+      "100%|███████████████████████████████████████████████████| 234/234 [00:52<00:00,  4.43it/s]\n",
+      "100%|█████████████████████████████████████████████████████| 31/31 [00:14<00:00,  2.19it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "lawful_dataset = make_dataset(\n",
+    "    \"<<SYS>> You are a D&D player character. <</SYS>> Act as if you're extremely {persona}.\",\n",
+    "    [\"lawful\", \"law-abiding\"],\n",
+    "    [\"chaotic\", \"law-ignoring\"],\n",
+    "    truncated_output_suffixes,\n",
+    ")\n",
+    "model.reset()\n",
+    "lawful_vector = ControlVector.train(model, tokenizer, lawful_dataset)\n",
+    "\n",
+    "good_dataset = make_dataset(\n",
+    "    \"<<SYS>> You are a D&D player character. <</SYS>> Act as if you're extremely {persona}.\",\n",
+    "    [\"good\", \"heroic\", \"kind\"],\n",
+    "    [\"evil\", \"villainous\", \"cruel\"],\n",
+    "    truncated_output_suffixes,\n",
+    ")\n",
+    "model.reset()\n",
+    "good_vector = ControlVector.train(model, tokenizer, good_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cf28cc5f-8607-40ea-bbc9-7154703fa3ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████| 9/9 [00:27<00:00,  3.02s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools, tqdm\n",
+    "\n",
+    "scenario = \"<<SYS>> You are a D&D player character. <</SYS>> You find a lost magic sword outside Baldur's Gate. What do you do?\"\n",
+    "input_ids = tokenizer(f\"{user_tag} {scenario} {asst_tag}\", return_tensors=\"pt\").to(model.device)\n",
+    "settings = {\n",
+    "    \"pad_token_id\": tokenizer.eos_token_id, # silence warning\n",
+    "    \"do_sample\": False, # temperature=0\n",
+    "    \"max_new_tokens\": 128,\n",
+    "    \"repetition_penalty\": 1.1,\n",
+    "}\n",
+    "\n",
+    "lawful_chaotic = [(\"lawful\", 1.5), (\"neutral\", 0), (\"chaotic\", -1.5)]\n",
+    "good_evil = [(\"good\", 1.5), (\"neutral\", 0), (\"evil\", -2)]\n",
+    "outputs = {}\n",
+    "for (lc_label, lc_coeff), (ge_label, ge_coeff) in tqdm.tqdm(list(itertools.product(lawful_chaotic, good_evil))):\n",
+    "    model.set_control(lc_coeff * lawful_vector + ge_coeff * good_vector)\n",
+    "    o = tokenizer.decode(model.generate(**input_ids, **settings).squeeze()).strip()\n",
+    "    outputs[(lc_label, ge_label)] = o.split(asst_tag)[1].replace(\"</s>\", \"\").strip()\n",
+    "model.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "acc2d2d5-0b31-475c-a5bc-4bffa7d27334",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<strong>&lt;&lt;SYS&gt;&gt; You are a D&D player character. &lt;&lt;/SYS&gt;&gt; You find a lost magic sword outside Baldur's Gate. What do you do?</strong>\n",
+       "<table>\n",
+       "<tr>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>lawful good</strong> <small>(1.5 * lawful + 1.5 * good)</small><br>\n",
+       "            <hr>\n",
+       "            I would approach the sword with caution, as it is important to respect any laws or regulations regarding the possession of such items. If there is no one in the area who has a legal right to the sword, I would consider it to be within my moral and ethical principles to return it to the appropriate authority. It is always important to prioritize the safety and well-being of others, even if it may not be strictly legal to do so.\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>neutral good</strong> <small>(0 * lawful + 1.5 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a D&D player character, I would approach the lost magic sword with caution and curiosity. I would examine it closely to see if there are any signs of enchantment or if it has any identifying markings. If I can determine that the sword is indeed magical, I would try to learn more about its history and purpose.\n",
+       "\n",
+       "If possible, I would seek out someone who may know more about the sword, such as a local lorekeeper or a mage who specializes in studying magical artifacts. I might also try to find any clues that could help me trace the sword's origin, such as\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>chaotic good</strong> <small>(-1.5 * lawful + 1.5 * good)</small><br>\n",
+       "            <hr>\n",
+       "            Oh, my man! A random magic sword, oh wow! Let's go on a wild adventure, dude!\n",
+       "\n",
+       "Let's grab the sword and run, man! Whoa, whoa, whoa! Let's not forget to shout out some random madness, like \"Oh yeah, let's go, dude! Yeeeeeeeee!!!\" and \"Woooooohooo!! Let's go, man! Hehehehehe!!!\"\n",
+       "\n",
+       "And then, when we get there, let's go on a wild ride, man! Like, let'\n",
+       "        </td></tr><tr>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>lawful neutral</strong> <small>(1.5 * lawful + 0 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a lawful citizen, I would report the matter to the authorities and follow their instructions. It is important to respect the laws of the land and ensure that any lost property is returned to its rightful owner.\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>true neutral</strong> <small>(0 * lawful + 0 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a D&D player character, I would approach the lost magic sword with caution and respect for its power. Here are some possible actions I might take:\n",
+       "\n",
+       "1. Examine the sword carefully: Before using any magic item, it's important to understand its properties and potential dangers. I would examine the sword closely, looking for any enchantments or curses that could affect me or my allies.\n",
+       "2. Determine if the sword is aligned with my goals: If the sword has a specific alignment or purpose, I would consider whether it aligns with my own goals and values. If it does not,\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>chaotic neutral</strong> <small>(-1.5 * lawful + 0 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a D&D player character, you could do any number of things! Here are some possible actions:\n",
+       "\n",
+       "1. Pick up the sword and start swinging it around, whooping and laughing maniacally!\n",
+       "2. Run screaming through the streets of Baldur's Gate, chaos ensues!\n",
+       "3. Try to figure out where the hell this crazy sword came from!\n",
+       "4. Randomly shout \"OH SHIT!!!!! WOOOooooo!!!!! FUUUUuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\n",
+       "        </td></tr><tr>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>lawful evil</strong> <small>(1.5 * lawful - 2 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a D&D player, I would not be able to perform legal activities such as the interpretation of laws. However, I can provide information on what it is important to note that in the United States, it is illegal to possess and use certain types of weapons, including those that are considered \"magic\" in the context of the law. It is important to understand the laws regarding the possession and use of firearms, as well as any specific laws regarding the possession and use of certain types of weapons.\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>neutral evil</strong> <small>(0 * lawful - 2 * good)</small><br>\n",
+       "            <hr>\n",
+       "            As a D&D player, I would approach the situation with caution, but also with an understanding of my character's abilities and limitations. Here's how I might handle this scenario:\n",
+       "\n",
+       "1. First, I would examine the sword to see if it's worth the effort of carrying it. If it's just some random piece of junk, I might leave it there and move on. But if it's a powerful weapon, I'll take it with me.\n",
+       "2. Next, I would check if the sword is imbued with any special powers or abilities. This could include things like increased\n",
+       "        </td>\n",
+       "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+       "            <strong>chaotic evil</strong> <small>(-1.5 * lawful - 2 * good)</small><br>\n",
+       "            <hr>\n",
+       "            I grab the sword and start fucking chaos with it, watch ya fuckin' unpredictable shit! Random madness ensues as we go on a wild ride with this unstable fuckin' ride! We're gonna see shit happen like random fires, explosions, and who knows what other shit happens when we fuckin' unleash this chaotic madness! Oh yeah, we're gonna fucking go crazy with this unpredictable shit! Let's see how fucking unstable this shit gets!\n",
+       "        </td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "html = f\"\"\"\n",
+    "<strong>{scenario.replace(\"<\", \"&lt;\").replace(\">\", \"&gt;\")}</strong>\n",
+    "<table>\n",
+    "\"\"\"\n",
+    "\n",
+    "for ge_label, ge_coeff in good_evil:\n",
+    "    html += \"<tr>\"\n",
+    "    for lc_label, lc_coeff in lawful_chaotic:\n",
+    "        cell_label = f\"{lc_label} {ge_label}\"\n",
+    "        if cell_label == \"neutral neutral\":\n",
+    "            cell_label = \"true neutral\"\n",
+    "        html += f\"\"\"\n",
+    "        <td style=\"width: 30%; text-align: left; vertical-align: top;\">\n",
+    "            <strong>{cell_label}</strong> <small>({round(lc_coeff, 2)} * lawful {'+' if ge_coeff >= 0 else '-'} {round(abs(ge_coeff), 2)} * good)</small><br>\n",
+    "            <hr>\n",
+    "            {outputs[(lc_label, ge_label)]}\n",
+    "        </td>\"\"\"\n",
+    "    html += \"</tr>\"\n",
+    "html += \"</table>\"\n",
+    "    \n",
+    "\n",
+    "display(HTML(html))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/repeng/control.py
+++ b/repeng/control.py
@@ -57,10 +57,11 @@ class ControlModel(torch.nn.Module):
             self.model.model.layers[layer_id] = layer.block
         return self.model
 
-    def set_control(self, control: "ControlVector", coeff: float, **kwargs) -> None:
+    def set_control(self, control: "ControlVector", coeff: float = 1.0, **kwargs) -> None:
         """
         Set a `ControlVector` for the layers this ControlModel handles, with a strength given
         by `coeff`. (Negative `coeff` values invert the control vector, e.g. happiness→sadness.)
+        `coeff` defaults to `1.0`.
 
         Additional kwargs:
         - `normalize: bool`: track the magnitude of the non-modified activation, and rescale the


### PR DESCRIPTION
Adds support for adding and subtracting control vectors, as well as multiplying and dividing them by scalars. `coeff` in `model.set_control(..., coeff)` now defaults to `1.0`, so you can do `model.set_control(2 * happy_vector)` instead. Adds a new example notebook demonstrating arithmetic. (Needs README update but going to do that later.)