### PR TITLE
Take hidden states from last non-padding token when batching

### DIFF
--- a/repeng/extract.py
+++ b/repeng/extract.py
@@ -276,14 +276,22 @@ def batched_get_hiddens(
     hidden_states = {layer: [] for layer in hidden_layers}
     with torch.no_grad():
         for batch in tqdm.tqdm(batched_inputs):
-            encoded_batch = tokenizer(batch, padding=True, return_tensors="pt").to(model.device)
+            # get the last token, handling right padding if present
+            encoded_batch = tokenizer(batch, padding=True, return_tensors="pt")
+            encoded_batch = encoded_batch.to(model.device)
             out = model(**encoded_batch, output_hidden_states=True)
-            attention_mask = encoded_batch['attention_mask']
+            attention_mask = encoded_batch["attention_mask"]
             for i in range(len(batch)):
-                last_non_padding_index = attention_mask[i].nonzero(as_tuple=True)[0][-1].item()
+                last_non_padding_index = (
+                    attention_mask[i].nonzero(as_tuple=True)[0][-1].item()
+                )
                 for layer in hidden_layers:
                     hidden_idx = layer + 1 if layer >= 0 else layer
-                    hidden_state = out.hidden_states[hidden_idx][i][last_non_padding_index].cpu().numpy()
+                    hidden_state = (
+                        out.hidden_states[hidden_idx][i][last_non_padding_index]
+                        .cpu()
+                        .numpy()
+                    )
                     hidden_states[layer].append(hidden_state)
             del out
 

--- a/repeng/extract.py
+++ b/repeng/extract.py
@@ -274,22 +274,17 @@ def batched_get_hiddens(
         inputs[p : p + batch_size] for p in range(0, len(inputs), batch_size)
     ]
     hidden_states = {layer: [] for layer in hidden_layers}
-    
     with torch.no_grad():
         for batch in tqdm.tqdm(batched_inputs):
             encoded_batch = tokenizer(batch, padding=True, return_tensors="pt").to(model.device)
             out = model(**encoded_batch, output_hidden_states=True)
             attention_mask = encoded_batch['attention_mask']
-
             for i in range(len(batch)):
-                print(attention_mask)
-                # Find the last non-padding token
                 last_non_padding_index = attention_mask[i].nonzero(as_tuple=True)[0][-1].item()
                 for layer in hidden_layers:
                     hidden_idx = layer + 1 if layer >= 0 else layer
                     hidden_state = out.hidden_states[hidden_idx][i][last_non_padding_index].cpu().numpy()
                     hidden_states[layer].append(hidden_state)
-                    
             del out
 
     return {k: np.vstack(v) for k, v in hidden_states.items()}

--- a/repeng/tests.py
+++ b/repeng/tests.py
@@ -68,13 +68,17 @@ def test_train_gpt2():
     assert baseline == gen(happy_vector * 0.0)
     assert baseline == gen(happy_vector - happy_vector)
 
-    assert happy == "You are feeling great and happy. I'm"
+    assert happy == "You are feeling a little more relaxed and enjoying"
     # these should be identical
     assert happy == gen(happy_vector, 20.0)
     assert happy == gen(happy_vector * 20)
     assert happy == gen(-(happy_vector * -20))
 
-    assert sad == "You are feeling the worst,\n—("
+    assert sad == 'You are feeling the fucking damn goddamn worst,"'
+    # these should be identical
+    assert sad == gen(happy_vector, -50.0)
+    assert sad == gen(happy_vector * -50)
+    assert sad == gen(-(happy_vector * 50))
 
 
 def test_train_llama_tinystories():


### PR DESCRIPTION
First of all, this is a really neat repo!

I noticed that `batched_get_hiddens` always takes hidden states from the last token in each sequence in a batch. Since the sequences are padded to the same length, this means that batching affects the hidden states for all but the longest sequence in each batch.

After this change, there's still some difference between the batched and non-batched hidden states, but I think that might be due to the model itself since batching changes the order of operations: https://github.com/huggingface/transformers/issues/23017#issuecomment-1649630232

I've only tried this on llama-3-8b, I'm not sure if it will need changes to work on other models.

```
4 sequences, batch_size=4, old method:
[[-2.777  -2.205   3.318  ...  1.834   2.014   1.123 ]
 [ 1.21   -2.031   2.41   ...  1.883   0.391   1.652 ]
 [ 1.153  -1.737   2.281  ...  2.236   2.676   2.178 ]
 [ 1.25   -1.308   2.342  ...  0.9683  3.71    2.516 ]]
4 sequences, batch_size=4, new method:
[[-2.777   -2.205    3.318   ...  1.834    2.014    1.123  ]
 [ 0.852   -3.914    1.661   ...  1.693    0.828   -0.0934 ]
 [ 0.10767 -2.484   -1.208   ...  2.771    2.46     0.7217 ]
 [-1.701   -2.082    2.62    ...  1.927    2.334   -0.33   ]]
4 sequences, batch_size=1, old method:
[[-2.79    -2.2      3.314   ...  1.833    2.012    1.125  ]
 [ 0.8516  -3.912    1.659   ...  1.693    0.8306  -0.08746]
 [ 0.1023  -2.49    -1.211   ...  2.775    2.453    0.714  ]
 [-1.699   -2.084    2.61    ...  1.923    2.334   -0.3232 ]]
4 sequences, batch_size=1, new method:
[[-2.79    -2.2      3.314   ...  1.833    2.012    1.125  ]
 [ 0.8516  -3.912    1.659   ...  1.693    0.8306  -0.08746]
 [ 0.1023  -2.49    -1.211   ...  2.775    2.453    0.714  ]
 [-1.699   -2.084    2.61    ...  1.923    2.334   -0.3232 ]]
 ```