### PR TITLE
[bugfix] remove erroneous signed param from SAE layer config

### DIFF
--- a/repeng/saes.py
+++ b/repeng/saes.py
@@ -74,6 +74,7 @@ def from_eleuther(
         with (layer_path / "cfg.json").open() as f:
             cfg_dict = json.load(f)
             d_in = cfg_dict.pop("d_in")
+            del cfg_dict['signed'] # param removed in SAE lib but not in uploaded HF configs
             cfg = eleuther_sae.SaeConfig(**cfg_dict)
 
         layer_sae = eleuther_sae.Sae(d_in, cfg, device=device, dtype=dtype)


### PR DESCRIPTION
eleuther's SAE library removed the signed param: https://github.com/EleutherAI/sae/pull/23/files#diff-6c69aa3bdde2eab407068f120a5b3eb62e26242fcbccb190a11df2d0dc3aa03bR24

but it's still present in the config files on huggingface. Loading the config with this param doesn't work, so just delete it.