### PR TITLE
rm token position

### DIFF
--- a/repeng/control.py
+++ b/repeng/control.py
@@ -166,24 +166,7 @@ class ControlModule(torch.nn.Module):
 
         norm_pre = torch.norm(modified, dim=-1, keepdim=True)
 
-        # we should ignore the padding tokens when doing the activation addition
-        # mask has ones for non padding tokens and zeros at padding tokens.
-        # only tested this on left padding
-        if "position_ids" in kwargs:
-            pos = kwargs["position_ids"]
-            zero_indices = (pos == 0).cumsum(1).argmax(1, keepdim=True)
-            col_indices = torch.arange(pos.size(1), device=pos.device).unsqueeze(0)
-            target_shape = modified.shape
-            mask = (
-                (col_indices >= zero_indices)
-                .float()
-                .reshape(target_shape[0], target_shape[1], 1)
-            )
-            mask = mask.to(modified.dtype).to(modified.device)
-        else:
-            mask = 1.0
-
-        modified = self.params.operator(modified, control * mask)
+        modified = self.params.operator(modified, control)
 
         if self.params.normalize:
             norm_post = torch.norm(modified, dim=-1, keepdim=True)


### PR DESCRIPTION
it was a good idea to mask here, but it breaks on all kinds of models e.g. "Qwen/Qwen3-4B-Instruct-2507" and "zai-org/GLM-4.1V-9B-Thinking" and I can't work out how to fix it easily (even using the attention mask is complicated as some models reshape the hidden state and so on). It might be worth disabling it.